### PR TITLE
カレンダー機能の実装

### DIFF
--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -10,7 +10,7 @@ const args = minimist(process.argv.slice(2));
 const now = dayjs();
 
 const startDate = dayjs(
-  new Date(args.y ?? now.year(), args.m ?? now.month() + 1 - 1, 1),
+  new Date(args.y ?? now.year(), (args.m ?? now.month()) - 1, 1),
 );
 
 const monthHeader = startDate.format("M月 YYYY");

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -39,5 +39,3 @@ for (
 if (calendarLine.length > 0) {
   console.log(calendarLine.join(" "));
 }
-
-console.log(" ".repeat(20));

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -29,17 +29,19 @@ let calendarLine = [];
 const firstDayOfWeek = targetDate.day();
 calendarLine = Array(firstDayOfWeek).fill("  ");
 
+let dateObj = targetDate;
+
 for (let day = 1; day <= dayMonth; day++) {
   const padded = String(day).padStart(2, " ");
   calendarLine.push(padded);
 
-  const dateObj = targetDate.set("date", day);
   const currentWeekday = dateObj.day();
 
   if (currentWeekday === 6) {
     console.log(calendarLine.join(" "));
     calendarLine = [];
   }
+  dateObj = dateObj.add(1, "day");
 }
 if (calendarLine.length > 0) {
   console.log(calendarLine.join(" "));

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -28,8 +28,8 @@ calendarLine += "   ".repeat(firstDayOfWeek);
 for (let day = 1; day <= dayMonth; day++) {
   const padded = String(day).padStart(2, " ");
   calendarLine += `${padded} `;
-  const currentDate = targetDate.date(day);
-  const currentWeekday = currentDate.day();
+  const dateObj = dayjs(`${year}-${month}-${day}`);
+  const currentWeekday = dateObj.day();
   if (currentWeekday === 6) {
     console.log(calendarLine);
     calendarLine = "";

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -5,10 +5,11 @@ import dayjs from "dayjs";
 const args = minimist(process.argv.slice(2));
 
 const now = dayjs();
-const year = args.y ?? now.year();
-const month = args.m ?? now.month() + 1;
+const targetDate = now
+  .set("year", args.y ?? now.year())
+  .set("month", (args.m ?? now.month() + 1) - 1)
+  .startOf("month");
 
-const targetDate = dayjs(`${year}-${month}-01`);
 const dayMonth = targetDate.daysInMonth();
 const monthName = targetDate.format("M月 YYYY");
 const dayOfWeek = "日 月 火 水 木 金 土";
@@ -24,7 +25,8 @@ calendarLine += "   ".repeat(firstDayOfWeek);
 for (let day = 1; day <= dayMonth; day++) {
   const padded = String(day).padStart(2, " ");
   calendarLine += `${padded} `;
-  const dateObj = dayjs(`${year}-${month}-${day}`);
+  const dateObj = targetDate.set("date", day);
+
   const currentWeekday = dateObj.day();
   if (currentWeekday === 6) {
     console.log(calendarLine);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 import minimist from "minimist";
 import dayjs from "dayjs";
 
@@ -10,7 +11,6 @@ const targetDate = now
   .set("month", (args.m ?? now.month() + 1) - 1)
   .startOf("month");
 
-const dayMonth = targetDate.daysInMonth();
 const monthName = targetDate.format("M月 YYYY");
 const dayOfWeek = "日 月 火 水 木 金 土";
 
@@ -27,21 +27,24 @@ console.log(dayOfWeek);
 const firstDayOfWeek = targetDate.day();
 let calendarLine = Array(firstDayOfWeek).fill("  ");
 
-let dateObj = targetDate;
+const endDate = targetDate.endOf("month");
 
-for (let day = 1; day <= dayMonth; day++) {
-  const padded = String(day).padStart(2, " ");
+for (
+  let dateObj = targetDate;
+  dateObj.isSame(endDate) || dateObj.isBefore(endDate);
+  dateObj = dateObj.add(1, "day")
+) {
+  const padded = String(dateObj.date()).padStart(2, " ");
   calendarLine.push(padded);
 
-  const currentWeekday = dateObj.day();
-
-  if (currentWeekday === 6) {
+  if (dateObj.day() === 6) {
     console.log(calendarLine.join(" "));
     calendarLine = [];
   }
-  dateObj = dateObj.add(1, "day");
 }
+
 if (calendarLine.length > 0) {
   console.log(calendarLine.join(" "));
 }
+
 console.log(" ".repeat(20));

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -3,13 +3,6 @@
 import minimist from "minimist";
 import dayjs from "dayjs";
 
-function centerText(text, width = 20) {
-  const padding = Math.max(0, width - text.length);
-  const padLeft = Math.floor(padding / 2);
-  const padRight = padding - padLeft;
-  return `${" ".repeat(padLeft)}${text}${" ".repeat(padRight)}`;
-}
-
 const args = minimist(process.argv.slice(2));
 
 const now = dayjs();
@@ -21,7 +14,7 @@ const targetDate = now
 const monthName = targetDate.format("M月 YYYY");
 const dayOfWeek = "日 月 火 水 木 金 土";
 
-console.log(centerText(`${monthName}`, 20));
+console.log(`      ${monthName}`);
 console.log(dayOfWeek);
 
 const firstDayOfWeek = targetDate.day();

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -5,10 +5,8 @@ import dayjs from "dayjs";
 const args = minimist(process.argv.slice(2));
 
 const now = dayjs();
-
-const currentDate = now;
-const year = args.y ?? currentDate.year();
-const month = args.m ?? currentDate.month() + 1;
+const year = args.y ?? now.year();
+const month = args.m ?? now.month() + 1;
 
 const targetDate = dayjs(`${year}-${month}-01`);
 const dayMonth = targetDate.daysInMonth();

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -9,9 +9,10 @@ dayjs.extend(isSameOrBefore);
 const args = minimist(process.argv.slice(2));
 const now = dayjs();
 
-const startDate = dayjs(
-  new Date(args.y ?? now.year(), (args.m ?? now.month()) - 1, 1),
-);
+const year = args.y ?? now.year();
+const month = (args.m ?? now.month()) - 1;
+
+const startDate = dayjs(new Date(year, month, 1));
 
 const monthHeader = startDate.format("M月 YYYY");
 const dayOfWeekHeader = "日 月 火 水 木 金 土";

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -8,11 +8,10 @@ dayjs.locale("ja");
 const args = minimist(process.argv.slice(2));
 
 const now = dayjs();
-const currentYear = now.year();
-const currentMonth = now.month() + 1;
 
-const year = args.y || currentYear;
-const month = args.m || currentMonth;
+const currentDate = now;
+const year = args.y || currentDate.year();
+const month = args.m || currentDate.month() + 1;
 
 const targetDate = dayjs(`${year}-${month}-01`);
 const dayMonth = targetDate.daysInMonth();

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -28,7 +28,9 @@ calendarLine += "   ".repeat(firstDayOfWeek);
 
 for (let day = 1; day <= dayMonth; day++) {
   const padded = String(day).padStart(2, " ");
-  calendarLine += padded + " ";
+  // 文字列結合ではなくテンプレート文字列
+  // calendarLine += padded + " ";
+  calendarLine += `${padded} `;
   const currentWeekday = (firstDayOfWeek + day - 1) % 7;
   if (currentWeekday === 6) {
     console.log(calendarLine.trimEnd() + "  ");

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -10,11 +10,11 @@ const args = minimist(process.argv.slice(2));
 const now = dayjs();
 
 const year = args.y ?? now.year();
-const month = args.m != null ? args.m - 1 : now.month();
+const month = args.m ?? now.month() + 1;
 
-const startDate = dayjs(new Date(year, month, 1));
+const startDate = dayjs(new Date(year, month - 1, 1));
 
-const monthHeader = startDate.format("M月 YYYY");
+const monthHeader = `${month}月 ${year}`;
 const dayOfWeekHeader = "日 月 火 水 木 金 土";
 
 console.log(`      ${monthHeader}`);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -3,7 +3,6 @@ import minimist from "minimist";
 import dayjs from "dayjs";
 import localeData from "dayjs/plugin/localeData.js";
 dayjs.extend(localeData);
-dayjs.locale("ja");
 
 const args = minimist(process.argv.slice(2));
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -17,8 +17,6 @@ const startDate = dayjs(
   ),
 );
 
-console.log(startDate);
-
 const monthHeader = startDate.format("M月 YYYY");
 const dayOfWeekHeader = "日 月 火 水 木 金 土";
 
@@ -31,7 +29,7 @@ const endDate = startDate.endOf("month");
 
 for (
   let currentDate = startDate;
-  currentDate.isSameOrBefore(endDate);
+  currentDate.isSameOrBefore(endDate, "day");
   currentDate = currentDate.add(1, "day")
 ) {
   const dayString = String(currentDate.date()).padStart(2, " ");

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -7,13 +7,11 @@ import isSameOrBefore from "dayjs/plugin/isSameOrBefore.js";
 dayjs.extend(isSameOrBefore);
 
 const args = minimist(process.argv.slice(2));
-
 const now = dayjs();
-
-const baseDate = now
-  .set("year", args.y ?? now.year())
-  .set("month", (args.m ?? now.month() + 1) - 1)
-  .startOf("month");
+const baseDate = dayjs()
+  .year(args.y ?? now.year())
+  .month((args.m ?? now.month() + 1) - 1)
+  .date(1);
 
 const monthHeader = baseDate.format("M月 YYYY");
 const dayOfWeekHeader = "日 月 火 水 木 金 土";
@@ -33,12 +31,8 @@ for (
   const dayString = String(currentDate.date()).padStart(2, " ");
   calendarLine.push(dayString);
 
-  if (currentDate.day() === 6) {
+  if (currentDate.day() === 6 || currentDate.isSame(endDate, "day")) {
     console.log(calendarLine.join(" "));
     calendarLine = [];
   }
-}
-
-if (calendarLine.length > 0) {
-  console.log(calendarLine.join(" "));
 }

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -3,6 +3,10 @@
 import minimist from "minimist";
 import dayjs from "dayjs";
 
+import isSameOrBefore from "dayjs/plugin/isSameOrBefore.js";
+
+dayjs.extend(isSameOrBefore);
+
 const args = minimist(process.argv.slice(2));
 
 const now = dayjs();

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 import minimist from "minimist";
 import dayjs from "dayjs";
-import localeData from "dayjs/plugin/localeData.js";
-dayjs.extend(localeData);
 
 const args = minimist(process.argv.slice(2));
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import minimist from "minimist";
 import dayjs from "dayjs";
 import localeData from "dayjs/plugin/localeData.js";

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -6,24 +6,24 @@ import dayjs from "dayjs";
 const args = minimist(process.argv.slice(2));
 
 const now = dayjs();
-const targetDate = now
+const baseMonth = now
   .set("year", args.y ?? now.year())
   .set("month", (args.m ?? now.month() + 1) - 1)
   .startOf("month");
 
-const monthHeader = targetDate.format("M月 YYYY");
+const monthHeader = baseMonth.format("M月 YYYY");
 const dayOfWeekHeader = "日 月 火 水 木 金 土";
 
 console.log(`      ${monthHeader}`);
 console.log(dayOfWeekHeader);
 
-const startDayIndex = targetDate.day();
+const startDayIndex = baseMonth.day();
 let calendarLine = Array(startDayIndex).fill("  ");
 
-const endDate = targetDate.endOf("month");
+const endDate = baseMonth.endOf("month");
 
 for (
-  let dateObj = targetDate;
+  let dateObj = baseMonth;
   dateObj.isSame(endDate) || dateObj.isBefore(endDate);
   dateObj = dateObj.add(1, "day")
 ) {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -23,14 +23,14 @@ let calendarLine = Array(startDayIndex).fill("  ");
 const endDate = baseMonth.endOf("month");
 
 for (
-  let dateObj = baseMonth;
-  dateObj.isSameOrBefore(endDate);
-  dateObj = dateObj.add(1, "day")
+  let currentDate = baseMonth;
+  currentDate.isSameOrBefore(endDate);
+  currentDate = currentDate.add(1, "day")
 ) {
-  const padded = String(dateObj.date()).padStart(2, " ");
+  const padded = String(currentDate.date()).padStart(2, " ");
   calendarLine.push(padded);
 
-  if (dateObj.day() === 6) {
+  if (currentDate.day() === 6) {
     console.log(calendarLine.join(" "));
     calendarLine = [];
   }

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -12,16 +12,14 @@ const now = dayjs();
 const year = args.y ?? now.year();
 const month = args.m ?? now.month() + 1;
 
-const startDate = dayjs(new Date(year, month - 1, 1));
-
 const monthHeader = `${month}月 ${year}`;
 const dayOfWeekHeader = "日 月 火 水 木 金 土";
 
 console.log(`      ${monthHeader}`);
 console.log(dayOfWeekHeader);
 
+const startDate = dayjs(new Date(year, month - 1, 1));
 let calendarLine = Array(startDate.day()).fill("  ");
-
 const endDate = startDate.endOf("month");
 
 for (

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -10,8 +10,6 @@ const args = minimist(process.argv.slice(2));
 const now = dayjs();
 
 const year = args.y ?? now.year();
-// const month = args.m ? args.m - 1 : now.month();
-// const month = (args.m ?? now.month() + 1) - 1;
 const month = args.m != null ? args.m - 1 : now.month();
 
 const startDate = dayjs(new Date(year, month, 1));

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -27,8 +27,8 @@ for (
   currentDate.isSameOrBefore(endDate);
   currentDate = currentDate.add(1, "day")
 ) {
-  const padded = String(currentDate.date()).padStart(2, " ");
-  calendarLine.push(padded);
+  const dayString = String(currentDate.date()).padStart(2, " ");
+  calendarLine.push(dayString);
 
   if (currentDate.day() === 6) {
     console.log(calendarLine.join(" "));

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -32,11 +32,11 @@ for (let day = 1; day <= dayMonth; day++) {
   const currentDate = targetDate.date(day);
   const currentWeekday = currentDate.day();
   if (currentWeekday === 6) {
-    console.log(calendarLine.trimEnd() + "  ");
+    console.log(calendarLine);
     calendarLine = "";
   }
 }
 if (calendarLine !== "") {
-  console.log(calendarLine.trimEnd().padEnd(22, " "));
+  console.log(calendarLine);
 }
 console.log(" ".repeat(22));

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -3,6 +3,13 @@
 import minimist from "minimist";
 import dayjs from "dayjs";
 
+function centerText(text, width = 20) {
+  const padding = Math.max(0, width - text.length);
+  const padLeft = Math.floor(padding / 2);
+  const padRight = padding - padLeft;
+  return `${" ".repeat(padLeft)}${text}${" ".repeat(padRight)}`;
+}
+
 const args = minimist(process.argv.slice(2));
 
 const now = dayjs();
@@ -13,13 +20,6 @@ const targetDate = now
 
 const monthName = targetDate.format("M月 YYYY");
 const dayOfWeek = "日 月 火 水 木 金 土";
-
-function centerText(text, width = 20) {
-  const padding = Math.max(0, width - text.length);
-  const padLeft = Math.floor(padding / 2);
-  const padRight = padding - padLeft;
-  return `${" ".repeat(padLeft)}${text}${" ".repeat(padRight)}`;
-}
 
 console.log(centerText(`${monthName}`, 20));
 console.log(dayOfWeek);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -9,12 +9,11 @@ dayjs.extend(isSameOrBefore);
 const args = minimist(process.argv.slice(2));
 
 const now = dayjs();
+
 const baseDate = now
   .set("year", args.y ?? now.year())
   .set("month", (args.m ?? now.month() + 1) - 1)
   .startOf("month");
-
-console.log(baseDate);
 
 const monthHeader = baseDate.format("M月 YYYY");
 const dayOfWeekHeader = "日 月 火 水 木 金 土";

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -8,23 +8,23 @@ dayjs.extend(isSameOrBefore);
 
 const args = minimist(process.argv.slice(2));
 const now = dayjs();
-const baseDate = dayjs()
+const firstDayOfMonth = dayjs()
   .year(args.y ?? now.year())
   .month((args.m ?? now.month() + 1) - 1)
   .date(1);
 
-const monthHeader = baseDate.format("M月 YYYY");
+const monthHeader = firstDayOfMonth.format("M月 YYYY");
 const dayOfWeekHeader = "日 月 火 水 木 金 土";
 
 console.log(`      ${monthHeader}`);
 console.log(dayOfWeekHeader);
 
-let calendarLine = Array(baseDate.day()).fill("  ");
+let calendarLine = Array(firstDayOfMonth.day()).fill("  ");
 
-const endDate = baseDate.endOf("month");
+const endDate = firstDayOfMonth.endOf("month");
 
 for (
-  let currentDate = baseDate;
+  let currentDate = firstDayOfMonth;
   currentDate.isSameOrBefore(endDate);
   currentDate = currentDate.add(1, "day")
 ) {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -8,23 +8,23 @@ dayjs.extend(isSameOrBefore);
 
 const args = minimist(process.argv.slice(2));
 const now = dayjs();
-const firstDayOfMonth = dayjs()
+const startDate = dayjs()
   .year(args.y ?? now.year())
   .month((args.m ?? now.month() + 1) - 1)
   .date(1);
 
-const monthHeader = firstDayOfMonth.format("M月 YYYY");
+const monthHeader = startDate.format("M月 YYYY");
 const dayOfWeekHeader = "日 月 火 水 木 金 土";
 
 console.log(`      ${monthHeader}`);
 console.log(dayOfWeekHeader);
 
-let calendarLine = Array(firstDayOfMonth.day()).fill("  ");
+let calendarLine = Array(startDate.day()).fill("  ");
 
-const endDate = firstDayOfMonth.endOf("month");
+const endDate = startDate.endOf("month");
 
 for (
-  let currentDate = firstDayOfMonth;
+  let currentDate = startDate;
   currentDate.isSameOrBefore(endDate);
   currentDate = currentDate.add(1, "day")
 ) {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -24,10 +24,8 @@ function centerText(text, width = 20) {
 console.log(centerText(`${monthName}`, 20));
 console.log(dayOfWeek);
 
-let calendarLine = [];
-
 const firstDayOfWeek = targetDate.day();
-calendarLine = Array(firstDayOfWeek).fill("  ");
+let calendarLine = Array(firstDayOfWeek).fill("  ");
 
 let dateObj = targetDate;
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -11,14 +11,14 @@ const targetDate = now
   .set("month", (args.m ?? now.month() + 1) - 1)
   .startOf("month");
 
-const monthName = targetDate.format("M月 YYYY");
-const dayOfWeek = "日 月 火 水 木 金 土";
+const monthHeader = targetDate.format("M月 YYYY");
+const dayOfWeekHeader = "日 月 火 水 木 金 土";
 
-console.log(`      ${monthName}`);
-console.log(dayOfWeek);
+console.log(`      ${monthHeader}`);
+console.log(dayOfWeekHeader);
 
-const firstDayOfWeek = targetDate.day();
-let calendarLine = Array(firstDayOfWeek).fill("  ");
+const startDayIndex = targetDate.day();
+let calendarLine = Array(startDayIndex).fill("  ");
 
 const endDate = targetDate.endOf("month");
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -10,11 +10,7 @@ const args = minimist(process.argv.slice(2));
 const now = dayjs();
 
 const startDate = dayjs(
-  new Date(
-    Number(args.y ?? now.year()),
-    Number(args.m ?? now.month() + 1) - 1,
-    1,
-  ),
+  new Date(args.y ?? now.year(), args.m ?? now.month() + 1 - 1, 1),
 );
 
 const monthHeader = startDate.format("M月 YYYY");

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -10,7 +10,9 @@ const args = minimist(process.argv.slice(2));
 const now = dayjs();
 
 const year = args.y ?? now.year();
-const month = args.m ? args.m - 1 : now.month();
+// const month = args.m ? args.m - 1 : now.month();
+// const month = (args.m ?? now.month() + 1) - 1;
+const month = args.m != null ? args.m - 1 : now.month();
 
 const startDate = dayjs(new Date(year, month, 1));
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -24,7 +24,7 @@ const endDate = baseMonth.endOf("month");
 
 for (
   let dateObj = baseMonth;
-  dateObj.isSame(endDate) || dateObj.isBefore(endDate);
+  dateObj.isSameOrBefore(endDate);
   dateObj = dateObj.add(1, "day")
 ) {
   const padded = String(dateObj.date()).padStart(2, " ");

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -10,7 +10,7 @@ const args = minimist(process.argv.slice(2));
 const now = dayjs();
 
 const year = args.y ?? now.year();
-const month = (args.m ?? now.month() + 1) - 1;
+const month = args.m ? args.m - 1 : now.month();
 
 const startDate = dayjs(new Date(year, month, 1));
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -18,7 +18,7 @@ function centerText(text, width = 20) {
   const padding = Math.max(0, width - text.length);
   const padLeft = Math.floor(padding / 2);
   const padRight = padding - padLeft;
-  return " ".repeat(padLeft) + text + " ".repeat(padRight);
+  return `${" ".repeat(padLeft)}${text}${" ".repeat(padRight)}`;
 }
 
 console.log(centerText(`${monthName}`, 20));

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -15,11 +15,11 @@ const month = args.m ?? currentDate.month() + 1;
 
 const targetDate = dayjs(`${year}-${month}-01`);
 const dayMonth = targetDate.daysInMonth();
-const monthName = targetDate.format("M月 YYYY年");
+const monthName = targetDate.format("M月 YYYY");
 const DayOfWeek = "日 月 火 水 木 金 土";
 
-console.log(monthName.padStart(14, " "));
-console.log(DayOfWeek);
+console.log("      " + monthName + "        ");
+console.log(DayOfWeek + "  ");
 
 const firstDayOfWeek = targetDate.day();
 let calendarLine = "";
@@ -31,10 +31,11 @@ for (let day = 1; day <= dayMonth; day++) {
   calendarLine += padded + " ";
   const currentWeekday = (firstDayOfWeek + day - 1) % 7;
   if (currentWeekday === 6) {
-    console.log(calendarLine.trimEnd());
+    console.log(calendarLine.trimEnd() + "  ");
     calendarLine = "";
   }
 }
 if (calendarLine !== "") {
-  console.log(calendarLine.trimEnd());
+  console.log(calendarLine.trimEnd().padEnd(22, " "));
 }
+console.log(" ".repeat(22));

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -10,8 +10,8 @@ const args = minimist(process.argv.slice(2));
 const now = dayjs();
 
 const currentDate = now;
-const year = args.y || currentDate.year();
-const month = args.m || currentDate.month() + 1;
+const year = args.y ?? currentDate.year();
+const month = args.m ?? currentDate.month() + 1;
 
 const targetDate = dayjs(`${year}-${month}-01`);
 const dayMonth = targetDate.daysInMonth();

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -24,23 +24,24 @@ function centerText(text, width = 20) {
 console.log(centerText(`${monthName}`, 20));
 console.log(dayOfWeek);
 
-const firstDayOfWeek = targetDate.day();
-let calendarLine = "";
+let calendarLine = [];
 
-calendarLine += "   ".repeat(firstDayOfWeek);
+const firstDayOfWeek = targetDate.day();
+calendarLine = Array(firstDayOfWeek).fill("  ");
 
 for (let day = 1; day <= dayMonth; day++) {
   const padded = String(day).padStart(2, " ");
-  calendarLine += `${padded} `;
-  const dateObj = targetDate.set("date", day);
+  calendarLine.push(padded);
 
+  const dateObj = targetDate.set("date", day);
   const currentWeekday = dateObj.day();
+
   if (currentWeekday === 6) {
-    console.log(calendarLine);
-    calendarLine = "";
+    console.log(calendarLine.join(" "));
+    calendarLine = [];
   }
 }
-if (calendarLine !== "") {
-  console.log(calendarLine);
+if (calendarLine.length > 0) {
+  console.log(calendarLine.join(" "));
 }
 console.log(" ".repeat(20));

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -2,7 +2,6 @@
 
 import minimist from "minimist";
 import dayjs from "dayjs";
-
 import isSameOrBefore from "dayjs/plugin/isSameOrBefore.js";
 
 dayjs.extend(isSameOrBefore);

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -16,10 +16,10 @@ const month = args.m ?? currentDate.month() + 1;
 const targetDate = dayjs(`${year}-${month}-01`);
 const dayMonth = targetDate.daysInMonth();
 const monthName = targetDate.format("M月 YYYY");
-const DayOfWeek = "日 月 火 水 木 金 土";
+const dayOfWeek = "日 月 火 水 木 金 土";
 
 console.log("      " + monthName + "        ");
-console.log(DayOfWeek + "  ");
+console.log(dayOfWeek + "  ");
 
 const firstDayOfWeek = targetDate.day();
 let calendarLine = "";

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -28,10 +28,9 @@ calendarLine += "   ".repeat(firstDayOfWeek);
 
 for (let day = 1; day <= dayMonth; day++) {
   const padded = String(day).padStart(2, " ");
-  // 文字列結合ではなくテンプレート文字列
-  // calendarLine += padded + " ";
   calendarLine += `${padded} `;
-  const currentWeekday = (firstDayOfWeek + day - 1) % 7;
+  const currentDate = targetDate.date(day);
+  const currentWeekday = currentDate.day();
   if (currentWeekday === 6) {
     console.log(calendarLine.trimEnd() + "  ");
     calendarLine = "";

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -10,7 +10,7 @@ const args = minimist(process.argv.slice(2));
 const now = dayjs();
 
 const year = args.y ?? now.year();
-const month = (args.m ?? now.month()) - 1;
+const month = (args.m ?? now.month() + 1) - 1;
 
 const startDate = dayjs(new Date(year, month, 1));
 

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -8,10 +8,16 @@ dayjs.extend(isSameOrBefore);
 
 const args = minimist(process.argv.slice(2));
 const now = dayjs();
-const startDate = dayjs()
-  .year(args.y ?? now.year())
-  .month((args.m ?? now.month() + 1) - 1)
-  .date(1);
+
+const startDate = dayjs(
+  new Date(
+    Number(args.y ?? now.year()),
+    Number(args.m ?? now.month() + 1) - 1,
+    1,
+  ),
+);
+
+console.log(startDate);
 
 const monthHeader = startDate.format("M月 YYYY");
 const dayOfWeekHeader = "日 月 火 水 木 金 土";

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -9,24 +9,25 @@ dayjs.extend(isSameOrBefore);
 const args = minimist(process.argv.slice(2));
 
 const now = dayjs();
-const baseMonth = now
+const baseDate = now
   .set("year", args.y ?? now.year())
   .set("month", (args.m ?? now.month() + 1) - 1)
   .startOf("month");
 
-const monthHeader = baseMonth.format("M月 YYYY");
+console.log(baseDate);
+
+const monthHeader = baseDate.format("M月 YYYY");
 const dayOfWeekHeader = "日 月 火 水 木 金 土";
 
 console.log(`      ${monthHeader}`);
 console.log(dayOfWeekHeader);
 
-const startDayIndex = baseMonth.day();
-let calendarLine = Array(startDayIndex).fill("  ");
+let calendarLine = Array(baseDate.day()).fill("  ");
 
-const endDate = baseMonth.endOf("month");
+const endDate = baseDate.endOf("month");
 
 for (
-  let currentDate = baseMonth;
+  let currentDate = baseDate;
   currentDate.isSameOrBefore(endDate);
   currentDate = currentDate.add(1, "day")
 ) {

--- a/02.calendar/cal.js
+++ b/02.calendar/cal.js
@@ -14,8 +14,15 @@ const dayMonth = targetDate.daysInMonth();
 const monthName = targetDate.format("M月 YYYY");
 const dayOfWeek = "日 月 火 水 木 金 土";
 
-console.log("      " + monthName + "        ");
-console.log(dayOfWeek + "  ");
+function centerText(text, width = 20) {
+  const padding = Math.max(0, width - text.length);
+  const padLeft = Math.floor(padding / 2);
+  const padRight = padding - padLeft;
+  return " ".repeat(padLeft) + text + " ".repeat(padRight);
+}
+
+console.log(centerText(`${monthName}`, 20));
+console.log(dayOfWeek);
 
 const firstDayOfWeek = targetDate.day();
 let calendarLine = "";
@@ -36,4 +43,4 @@ for (let day = 1; day <= dayMonth; day++) {
 if (calendarLine !== "") {
   console.log(calendarLine);
 }
-console.log(" ".repeat(22));
+console.log(" ".repeat(20));

--- a/02.calendar/calender.js
+++ b/02.calendar/calender.js
@@ -1,0 +1,40 @@
+import minimist from "minimist";
+import dayjs from "dayjs";
+import localeData from "dayjs/plugin/localeData.js";
+dayjs.extend(localeData);
+dayjs.locale("ja");
+
+const args = minimist(process.argv.slice(2));
+
+const now = dayjs();
+const currentYear = now.year();
+const currentMonth = now.month() + 1;
+
+const year = args.y || currentYear;
+const month = args.m || currentMonth;
+
+const targetDate = dayjs(`${year}-${month}-01`);
+const dayMonth = targetDate.daysInMonth();
+const monthName = targetDate.format("M月 YYYY年");
+const DayOfWeek = "日 月 火 水 木 金 土";
+
+console.log(monthName.padStart(14, " "));
+console.log(DayOfWeek);
+
+const firstDayOfWeek = targetDate.day();
+let calendarLine = "";
+
+calendarLine += "   ".repeat(firstDayOfWeek);
+
+for (let day = 1; day <= dayMonth; day++) {
+  const padded = String(day).padStart(2, " ");
+  calendarLine += padded + " ";
+  const currentWeekday = (firstDayOfWeek + day - 1) % 7;
+  if (currentWeekday === 6) {
+    console.log(calendarLine.trimEnd());
+    calendarLine = "";
+  }
+}
+if (calendarLine !== "") {
+  console.log(calendarLine.trimEnd());
+}

--- a/02.calendar/package-lock.json
+++ b/02.calendar/package-lock.json
@@ -4,9 +4,12 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "dayjs": "^1.11.13"
+      },
       "devDependencies": {
         "@eslint/js": "^9.16.0",
-        "eslint": "^9.16.0",
+        "eslint": "^9.31.0",
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.13.0",
         "prettier": "^3.4.2"
@@ -47,13 +50,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
-      "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.5",
+        "@eslint/object-schema": "^2.1.6",
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
@@ -61,10 +64,20 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@eslint/core": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
-      "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -75,9 +88,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -112,19 +125,22 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.16.0.tgz",
-      "integrity": "sha512-tw2HxzQkrbeuvyj1tG2Yqq+0H9wGoI2IMk4EOsQeX+vmd75FtJAzf+gTA69WF+baUKRYQ3x2kbLE08js5OsTVg==",
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
+      "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
-      "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -132,12 +148,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
-      "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
+      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@eslint/core": "^0.15.1",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -196,9 +213,9 @@
       }
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-      "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -224,9 +241,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -293,9 +310,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -369,10 +386,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -406,32 +429,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.16.0.tgz",
-      "integrity": "sha512-whp8mSQI4C8VXd+fLgSM0lh3UlmcFtVwUQjyKCFfsp+2ItAIYhlq/hqGahGqHE6cv9unM41VlqKk2VtKYR2TaA==",
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
+      "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.9.0",
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.16.0",
-        "@eslint/plugin-kit": "^0.2.3",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.0",
+        "@eslint/core": "^0.15.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.31.0",
+        "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.1",
+        "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.5",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.2.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -478,9 +502,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-      "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -507,9 +531,9 @@
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -520,15 +544,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-      "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.0"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -538,9 +562,9 @@
       }
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-      "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -705,9 +729,9 @@
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/02.calendar/package-lock.json
+++ b/02.calendar/package-lock.json
@@ -5,11 +5,12 @@
   "packages": {
     "": {
       "dependencies": {
-        "dayjs": "^1.11.13"
+        "dayjs": "^1.11.13",
+        "minimist": "^1.2.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.16.0",
-        "eslint": "^9.31.0",
+        "eslint": "^9.16.0",
         "eslint-config-prettier": "^9.1.0",
         "globals": "^15.13.0",
         "prettier": "^3.4.2"
@@ -50,9 +51,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
+      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -64,20 +65,10 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@eslint/config-helpers": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
-      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
     "node_modules/@eslint/core": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
+      "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -148,14 +139,27 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-      "integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+      "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.1",
+        "@eslint/core": "^0.13.0",
         "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+      "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -429,33 +433,32 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
-      "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.16.0.tgz",
+      "integrity": "sha512-whp8mSQI4C8VXd+fLgSM0lh3UlmcFtVwUQjyKCFfsp+2ItAIYhlq/hqGahGqHE6cv9unM41VlqKk2VtKYR2TaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.0",
-        "@eslint/config-helpers": "^0.3.0",
-        "@eslint/core": "^0.15.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.31.0",
-        "@eslint/plugin-kit": "^0.3.1",
+        "@eslint/config-array": "^0.19.0",
+        "@eslint/core": "^0.9.0",
+        "@eslint/eslintrc": "^3.2.0",
+        "@eslint/js": "9.16.0",
+        "@eslint/plugin-kit": "^0.2.3",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
+        "@humanwhocodes/retry": "^0.4.1",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.6",
+        "cross-spawn": "^7.0.5",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
+        "eslint-scope": "^8.2.0",
+        "eslint-visitor-keys": "^4.2.0",
+        "espree": "^10.3.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -528,6 +531,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.16.0.tgz",
+      "integrity": "sha512-tw2HxzQkrbeuvyj1tG2Yqq+0H9wGoI2IMk4EOsQeX+vmd75FtJAzf+gTA69WF+baUKRYQ3x2kbLE08js5OsTVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -868,6 +881,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/ms": {

--- a/02.calendar/package.json
+++ b/02.calendar/package.json
@@ -12,6 +12,7 @@
   },
   "type": "module",
   "dependencies": {
-    "dayjs": "^1.11.13"
+    "dayjs": "^1.11.13",
+    "minimist": "^1.2.8"
   }
 }

--- a/02.calendar/package.json
+++ b/02.calendar/package.json
@@ -5,10 +5,13 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.16.0",
-    "eslint": "^9.16.0",
+    "eslint": "^9.31.0",
     "eslint-config-prettier": "^9.1.0",
     "globals": "^15.13.0",
     "prettier": "^3.4.2"
   },
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "dayjs": "^1.11.13"
+  }
 }

--- a/02.calendar/package.json
+++ b/02.calendar/package.json
@@ -5,7 +5,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.16.0",
-    "eslint": "^9.31.0",
+    "eslint": "^9.16.0",
     "eslint-config-prettier": "^9.1.0",
     "globals": "^15.13.0",
     "prettier": "^3.4.2"


### PR DESCRIPTION
### calenderコードの実装
minimistとdayjsを使用して実装しました。

`dayjs`	日付を扱うライブラリ。Moment.js風のAPI
`localeData`	dayjsのプラグイン。曜日などのロケール情報を使用できるようにする
`args`	コマンドライン引数（例: -y 2025 -m 7 のような入力をオブジェクト化）
`now`	現在の日時を表す dayjs() オブジェクト
`currentYear`	現在の年。例：2025
`currentMonth`	現在の月（1〜12）。注意：dayjs().month() は 0 始まりなので +1 して補正
`year`	カレンダーに使う年。引数 -y があればその値、なければ currentYear
`month`	カレンダーに使う月。引数 -m があればその値、なければ currentMonth
`dayMonth`	指定された月の「日数」
`monthName`	ヘッダーに表示する「○月 ○○○○年」
`DayOfWeek`	曜日名の並び（日〜土）を文字列として表示用
`firstDayOfWeek`	該当月の1日が「何曜日」か（0:日曜〜6:土曜）
`day`（ループ）	カレンダーの日付を表すループ変数（1〜末日）
`padded`	指定した幅になるように調整した後の
`calendarLine`	その週の1行分の日付
`targetDate`	指定された年と月のdayjsオブジェクト


calendarLineに1週間分の日付を格納して、土曜日（6）だった場合は空にして次の週に移るようにしました。
